### PR TITLE
Improved bench.hrl formatting.

### DIFF
--- a/bench.hrl
+++ b/bench.hrl
@@ -2,10 +2,12 @@ bench(Name, Fun, Trials) ->
     print_result(Name, repeat_tc(Fun, Trials)).
 
 repeat_tc(Fun, Trials) ->
-    timer:tc(fun() -> repeat(Trials, Fun) end).
+    {Time, _} = timer:tc(fun() -> repeat(Trials, Fun) end),
+    {Time, Trials}.
 
 repeat(0, _Fun) -> ok;
 repeat(N, Fun) -> Fun(), repeat(N - 1, Fun).
 
-print_result(Name, {Time, _}) ->
-    io:format("~s: ~w~n", [Name, Time div 1000]).
+print_result(Name, {Time, Trials}) ->
+    io:format("~s: ~.3f us (~.2f per second)~n",
+              [Name, Time / Trials, Trials / (Time / 1000000)]).


### PR DESCRIPTION
I improved (for my use case, anyway) the formatting of the benchamark output. Before:

```
etst - lookup1: 982 ms
etst - lookup2: 266 ms
```

After:

```
retrie - insert: 4732.690 us (211.30 per second)
retrie - lookup: 0.263 us (3806869.88 per second)
```

The first value is the time it takes a single tested operation to complete on average and the second value is how many operations were completed in a second (again, on average).

Not sure if you will like this, I just thought I'd give you the chance to merge. :)
